### PR TITLE
fix: some parsing fixes

### DIFF
--- a/src/doll.py
+++ b/src/doll.py
@@ -99,15 +99,12 @@ class Doll:
         self.full_name = get_template_param_value(template, "fullname")
         self.role = get_template_param_value(template, "role")
         self.rarity = get_template_param_value(template, "rarity")
-        self.affiliation = get_template_param_value(template, "affiliation")
+        self.affiliation = simplify(get_template_param_value(template, "affiliation"))
         self.weapon_name = get_template_param_value(template, "favweapon")
         self.weapon_weakness = get_template_param_value(template, "wepweakness")
         self.phase_weakness = get_template_param_value(template, "phaseweakness")
         self.gfl_name = get_template_param_value(template, "GFL")
-
-        self.signature_weapon = None
-        if self._STANDARD_RARITY not in self.rarity:
-            self.signature_weapon = get_template_param_value(template, "imprint")
+        self.signature_weapon = get_template_param_value(template, "imprint")
 
         self.nodes = self._get_nodes(template)
         self.skills = self._get_skills(doll_skills)
@@ -166,7 +163,6 @@ class Doll:
 
         skills = []
         for skill_data in doll_skills:
-
             skill = self._parse_skill_table(skill_data)
             skills.append(skill)
 

--- a/src/parse_utils.py
+++ b/src/parse_utils.py
@@ -44,7 +44,9 @@ def get_template_param_value(template, param_name):
     Internal function to get the value of a parameter
     """
 
-    return template.get_arg(param_name).value
+    param = template.get_arg(param_name)
+
+    return param.value if param is not None else None
 
 
 def remove_wikilinks(wikitext):
@@ -56,11 +58,14 @@ def remove_wikilinks(wikitext):
     wikilinks = wtp.parse(wikitext).wikilinks
 
     for wikilink in wikilinks:
+        value = None
         if wikilink.text == None:
-            continue
+            value = wikilink.title
+        else:
+            value = wikilink.text
 
         wikilink_str = str(wikilink)
-        wikitext = wikitext.replace(wikilink_str, wikilink.text)
+        wikitext = wikitext.replace(wikilink_str, value)
 
     return wikitext
 

--- a/src/responder.py
+++ b/src/responder.py
@@ -329,7 +329,7 @@ class Responder:
 
         embed = Embed(
             title=doll.full_name,
-            description=f"{doll.gfl_name}",
+            description=f"{doll.gfl_name if doll.gfl_name is not None else ""}",
             color=Color.orange(),
         )
 
@@ -337,8 +337,8 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                !!!\nShikikan, Lenna failed to fetch data for this doll, but Lenna remembers them! Make sure to check the data out and see what Lenna missed!\n!!!",
-                """
+                    !!!\nShikikan, Lenna failed to fetch data for this doll, but Lenna remembers them! Make sure to check the data out and see what Lenna missed!\n!!!"
+                    """
                 )
             )
 
@@ -492,7 +492,7 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                !!!\nShikikan, Lenna failed to fetch data for this weapon, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!",
+                !!!\nShikikan, Lenna failed to fetch data for this weapon, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!"
                 """
                 )
             )
@@ -589,7 +589,7 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                !!!\nShikikan, Lenna failed to fetch data for this status effect, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!",
+                !!!\nShikikan, Lenna failed to fetch data for this status effect, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!"
                 """
                 )
             )


### PR DESCRIPTION
if a wikitext template does not have an argument, it will return None now instead of failing

if a wikilink does not have a text, replace the wikilink with its title now.