### PR TITLE
fix: weapon parsing fix

### DIFF
--- a/data/media.json
+++ b/data/media.json
@@ -1,5 +1,6 @@
 {
     "lenna_bingo_video": "https://cdn.discordapp.com/attachments/838924737929150484/1306881510896304208/Messenger_creation_FACECD4A-FD40-4336-8242-45783DBB8379.mp4?ex=67ca9e40&is=67c94cc0&hm=5a010ffa28296f3a6762ccf0af48ebb6d8e9e568786dcad583caafd04971a987&",
     "lenna_smile_png": "https://cdn.discordapp.com/attachments/1346784097716011104/1347142314623238215/maxresdefault-2674508715.jpg?ex=67cabf8c&is=67c96e0c&hm=fbd4afc99eeb933c0109a62acdd6d62ffa728db1943f467147c5d3aab2cbb1b8&",
-    "leva_bingo_video": "https://cdn.discordapp.com/attachments/1263921836475945122/1318851539204444191/LevaBingo.mp4?ex=67f6d2f6&is=67f58176&hm=f0d34436086cea3e52aeb77333719f8ff0060af79875b835b6913ed2d96a61ad&"
+    "leva_bingo_video": "https://cdn.discordapp.com/attachments/1263921836475945122/1318851539204444191/LevaBingo.mp4?ex=67f6d2f6&is=67f58176&hm=f0d34436086cea3e52aeb77333719f8ff0060af79875b835b6913ed2d96a61ad&",
+    "silver_wolf_pull_gif": "https://media.discordapp.net/attachments/1100736975708880998/1170276772894494780/bronya_justpull.gif?ex=6800116d&is=67febfed&hm=53fdd055f7eb4cb4e4d01ad8844495c7e4ec7b7a07877a054424586e79e6fd9b&"
 }

--- a/src/parse_utils.py
+++ b/src/parse_utils.py
@@ -21,6 +21,12 @@ KEY_INDEX = 0
 FIRST_VALUE_INDEX = 1
 SIMPLE_DATA_LIST_LENGTH = 2
 
+# Cleanup
+BREAK_STR = "<br>"
+SPACE_STR = " "
+SINGLE_QUOTES_STR = "'"
+EMPTY_STR = ""
+
 
 def get_wikitext(json_obj):
     """
@@ -100,6 +106,13 @@ def simplify(wikitext):
     wikitext = remove_templates(wikitext)
 
     return wikitext
+
+
+def cleanup_string(string):
+    clean_string = string.replace(BREAK_STR, SPACE_STR)
+    clean_string = clean_string.replace(SINGLE_QUOTES_STR, EMPTY_STR)
+
+    return clean_string
 
 
 def table_data_to_dict(table_data):

--- a/src/responder.py
+++ b/src/responder.py
@@ -17,6 +17,10 @@ from typing import TypedDict
 
 from doll import Doll
 from weapons import Weapons
+from special_names import (
+    SPECIAL_DOLL_NAMES,
+    SPECIAL_WEAPON_NAMES,
+)
 from status_effects import StatusEffects
 from parse_utils import (
     get_wikitext,
@@ -27,18 +31,6 @@ IOPWIKI_DATA_FETCH_PARAM = "?action=parse&prop=wikitext&format=json&redirects=1&
 IOPWIKI_INFO_FETCH_PARAM = "?action=query&format=json&prop=info&titles="
 IOPWIKI_WEAPONS_PAGE = "GFL2_Weapons"
 IOPWIKI_STATUS_EFFECTS_PAGE = "GFL2_Status_Effects"
-
-SPECIAL_NAMES = {
-    "Centaureissi": "Centaureissi_(GFL2)",
-    "Daiyan": "Daiyan_(GFL2)",
-    "Dushevnaya": "Dushevnaya_(GFL2)",
-    "Jiangyu": "Jiangyu_(GFL2)",
-    "Mosin-Nagant": "Mosin-Nagant_(GFL2)",
-    "Springfield": "Springfield_(GFL2)",
-    "Suomi": "Suomi_(GFL2)",
-    "Vector": "Vector_(GFL2)",
-    "Ksenia": "Ksenia_(GFL2)",
-}
 
 
 class InvalidMediaException(Exception):
@@ -337,7 +329,7 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                    !!!\nShikikan, Lenna failed to fetch data for this doll, but Lenna remembers them! Make sure to check the data out and see what Lenna missed!\n!!!"
+                    !!!\nShikikan, Lenna failed to fetch data for this doll, but Lenna remembers them! Make sure to check the data out and see what Lenna missed!\n!!!
                     """
                 )
             )
@@ -428,6 +420,7 @@ class Responder:
         """
 
         updateable = True
+        weapon_name = SPECIAL_WEAPON_NAMES.get(weapon_name, weapon_name)
         weapons_cache_directory = f"{self._CACHE_DIRECTORY}{self._WEAPONS_CACHE_FILE}"
         weapons_query_url = (
             f"{IOPWIKI_API_URL}{IOPWIKI_DATA_FETCH_PARAM}{IOPWIKI_WEAPONS_PAGE}"
@@ -492,7 +485,7 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                !!!\nShikikan, Lenna failed to fetch data for this weapon, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!"
+                !!!\nShikikan, Lenna failed to fetch data for this weapon, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!
                 """
                 )
             )
@@ -589,7 +582,7 @@ class Responder:
             embed.set_footer(
                 text=dedent(
                     """
-                !!!\nShikikan, Lenna failed to fetch data for this status effect, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!"
+                !!!\nShikikan, Lenna failed to fetch data for this status effect, but Lenna remembers it! Make sure to check the data out and see what Lenna missed!\n!!!
                 """
                 )
             )
@@ -633,7 +626,7 @@ class Responder:
 
         doll_file_directory = f"{self._CACHE_DIRECTORY}{doll_name.lower()}.json"
 
-        doll_name = SPECIAL_NAMES.get(doll_name, doll_name)
+        doll_name = SPECIAL_DOLL_NAMES.get(doll_name, doll_name)
         query_url = f"{IOPWIKI_API_URL}{IOPWIKI_DATA_FETCH_PARAM}{doll_name}"
 
         raw_doll_data, update, updateable = self._query_wiki(
@@ -658,7 +651,7 @@ class Responder:
         raw_skill_list = []
         update_list = []
         skill_directories = []
-        query_doll_name = SPECIAL_NAMES.get(doll_name, doll_name)
+        query_doll_name = SPECIAL_DOLL_NAMES.get(doll_name, doll_name)
         updateable = True
         for i in range(self._SKILL_START_RANGE, self._SKILL_END_RANGE):
             skill_index = "" if i == 1 else i

--- a/src/special_names.py
+++ b/src/special_names.py
@@ -1,0 +1,35 @@
+"""
+A holder file for some special names for parsing
+"""
+
+SPECIAL_DOLL_NAMES = {
+    "Centaureissi": "Centaureissi_(GFL2)",
+    "Daiyan": "Daiyan_(GFL2)",
+    "Dushevnaya": "Dushevnaya_(GFL2)",
+    "Jiangyu": "Jiangyu_(GFL2)",
+    "Mosin-Nagant": "Mosin-Nagant_(GFL2)",
+    "Springfield": "Springfield_(GFL2)",
+    "Suomi": "Suomi_(GFL2)",
+    "Vector": "Vector_(GFL2)",
+    "Ksenia": "Ksenia_(GFL2)",
+}
+
+SPECIAL_WEAPON_NAMES = {
+    ".380 curva": ".380 curva (taurus curve)",
+    "taurus curve": ".380 curva (taurus curve)",
+    "416": "416 (hk416)",
+    "hk416": "416 (hk416)",
+    "model alpha": "model alpha (ak-alpha)",
+    "ak-alpha": "model alpha (ak-alpha)",
+    "sturmgewehr 36": "sturmgewehr 36 (g36)",
+    "g36": "sturmgewehr 36 (g36)",
+    "w 2000": "w 2000 (wa2000)",
+    "w2000": "w 2000 (wa2000)",
+    "wa2000": "w 2000 (wa2000)",
+    ".50 nemesis": ".50 nemesis (om 50/san 511)",
+    "om 50": ".50 nemesis (om 50/san 511)",
+    "san 511": ".50 nemesis (om 50/san 511)",
+    "mjolnir": "mjölnir",
+    "sportivo calibro 12": "sportivo calibro 12 (spas-12)",
+    "spas-12": "sportivo calibro 12 (spas-12)",
+}

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -17,6 +17,7 @@ from responder import Responder
 
 LENNA_BINGO_VIDEO = "lenna_bingo_video"
 LEVA_BINGO_VIDEO = "leva_bingo_video"
+JUST_PULL_GIF = "silver_wolf_pull_gif"
 ADMIN_ROLES_FILE = "../data/admin.txt"
 
 
@@ -53,6 +54,7 @@ class Watcher:
 
         self._add_command("help", Watcher.help)
         self._add_command("bingo", Watcher.bingo)
+        self._add_command("just_pull", Watcher.just_pull)
         self._add_command("echo", Watcher.echo)
         self._add_command("doll", Watcher.doll)
         self._add_command("mdoll", Watcher.mdoll)
@@ -104,6 +106,16 @@ class Watcher:
             bingo_video = self.responder.get_media(LEVA_BINGO_VIDEO)
 
         await ctx.send(bingo_video)
+
+    async def just_pull(self, ctx):
+        """
+        What r u even talkin abt
+        Don't ask
+        Don't hesitate
+        Just pull
+        """
+
+        await ctx.send(self.responder.get_media(JUST_PULL_GIF))
 
     async def echo(self, ctx, *args):
         """

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -303,7 +303,7 @@ class Watcher:
 
         embed = None
         try:
-            fixed_weapon_name = self._fix_name(weapon_name)
+            fixed_weapon_name = weapon_name.lower()
             embed = self.responder.get_weapon(
                 fixed_weapon_name,
                 force=force,

--- a/src/weapons.py
+++ b/src/weapons.py
@@ -9,6 +9,7 @@ from enum import Enum
 import wikitextparser as wtp
 
 from parse_utils import (
+    cleanup_string,
     simplify,
     table_data_to_dict,
 )
@@ -37,11 +38,13 @@ class Weapons:
     Weapons class definition
     """
 
+    # Parsing vars
     _WEAPON_GRADE_INDEX = 0
     _WEAPON_DESCRIPTION_INDEX = 2
     _WEAPON_SKILL_INDEX = 3
     _WEAPON_TRAIT_INDEX = 4
     _WEAPON_IMPRINT_INDEX = 5
+    _WEAPON_DATA_START_INDEX = 2
 
     class WeaponType(Enum):
         HG = 0
@@ -51,8 +54,6 @@ class Weapons:
         MG = 4
         SG = 5
         BLADE = 6
-
-    _WEAPON_DATA_START_INDEX = 2
 
     def __init__(self, weapons_json):
         self.weapons = self._parse_weapons_wikitable(weapons_json)
@@ -103,9 +104,13 @@ class Weapons:
 
             for weapon_name in weapons_dict:
                 weapon_info = weapons_dict[weapon_name]
+
+                # Prune and lowercase weapon names to make them easier to key through
+                pruned_weapon_name = cleanup_string(weapon_name).lower()
+
                 weapon = Weapon(
                     weapon_type.name,
-                    weapon_name,
+                    cleanup_string(weapon_name),
                     simplify(weapon_info[self._WEAPON_GRADE_INDEX]),
                     simplify(weapon_info[self._WEAPON_DESCRIPTION_INDEX]),
                     simplify(weapon_info[self._WEAPON_SKILL_INDEX]),
@@ -113,6 +118,6 @@ class Weapons:
                     simplify(weapon_info[self._WEAPON_IMPRINT_INDEX]),
                 )
 
-                weapons_dictionary[weapon_name] = weapon
+                weapons_dictionary[pruned_weapon_name] = weapon
 
         return weapons_dictionary


### PR DESCRIPTION
fixes weapon parsing issue caused by some weapons on the wiki being formatted for wikitext

e.g., `416<br>(''HK416'')`

now, they are cleaned up, saved as `416 (HK416)`

also made a hardcoded dictionary for special names to make it easier for user query.
e.g., users can now look up `416` or `hk416` to get `416 (HK416)`

also added silverwolf's just pull gif